### PR TITLE
fix: allow multiple documents for check-yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-toml
       - id: check-xml
       - id: check-yaml
-        exclude: roles/k8s_control_planes/files/kube-apiserver-to-kubelet.yaml
+        args: [--allow-multiple-documents]
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: no-commit-to-branch


### PR DESCRIPTION
Allow check-yaml to run without bailing out with multiple document errors.